### PR TITLE
Fix container for linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ CATKIN_IGNORE
 
 # IDE
 .vscode/
+
+# X11 Authentication cookie
+.docker.xauth

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ WORKDIR $MAIN_WS
 
 
 COPY entrypoint.sh /setup/entrypoint.sh
+RUN chmod +x /setup/entrypoint.sh
 ENTRYPOINT ["/setup/entrypoint.sh"]
 
 SHELL ["/bin/bash", "-c"]

--- a/README.md
+++ b/README.md
@@ -43,11 +43,26 @@ docker compose up mac
 There is a problem that OpenGL does not work because docker cannot find a graphics driver. If you find a solution, contact me.
 
 # On Linux
-This has not been tested, but run the following code and pray:
+Most modern Linux distribution have some form of authentication when connecting to the X11 server. Therefore docker will need some way to authenticate their permission to open GUI applications.
+Run the following on your host system first to allow for GUI applications:
+```
+xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f .docker.xauth nmerge -
+```
+
+Ignore below output, it is expected:
+```
+xauth:  file .docker.xauth does not exist
+```
+
+Run the following and pray:
 ```
 docker compose up linux
 ```
 
+You might need root permissions to run a container, this can be avoided by adding your user to the docker group:
+```
+sudo usermod -a -G docker $USER
+```
 
 # Running Docker
 Every time you want to use this project, run

--- a/compose.yaml
+++ b/compose.yaml
@@ -46,6 +46,11 @@ services:
     build:
       target: robot_dev_linux
     environment:
-      - DISPLAY=host.docker.internal:0
+      - DISPLAY=${DISPLAY}
+      - XAUTHORITY=/tmp/.docker.xauth
     volumes:
       - "/tmp/.X11-unix:/tmp/.X11-unix"
+      - type: bind
+        source: ./.docker.xauth
+        target: /tmp/.docker.xauth
+


### PR DESCRIPTION
Fixes the docker container on linux.

- the entrypoint script needs executable permissions
- X11 requires authentication to run GUI apps from docker
- user need to be part of docker group to avoid running with root

Tested on Ubuntu 22.04.01. GUI applications such as `rqt` works